### PR TITLE
style: add spoiler tags to ban notifications

### DIFF
--- a/stores/SyncConfigStore.js
+++ b/stores/SyncConfigStore.js
@@ -22,8 +22,9 @@ class SyncConfigStore extends Collection {
 						description: [
 							`New member **${member.username}#${member.discriminator}** (${member.id})`,
 							` has been banned from your currently synced server.\n`,
-							`Reason:\n`,
-							logs[0].reason
+							`Reason:\n||`,
+							logs[0].reason,
+							`||`
 						].join(""),
 						color: parseInt("aa5555", 16)
 					}})


### PR DESCRIPTION
When notifying synced servers of bans, put the reason in spoilers so as to let staff take a moment to brace before reading potentially triggering content.